### PR TITLE
Batch processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 *.ipynb_checkpoints
 *.pickle
 *.pkl
+*.icloud
 cache/
 # C extensions
 *.so

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ Cherche provides different [retrievers](https://raphaelsty.github.io/cherche/ret
 
 Cherche rankers are compatible with [SentenceTransformers](https://www.sbert.net/docs/pretrained_models.html) models, [Hugging Face sentence similarity](https://huggingface.co/models?pipeline_tag=zero-shot-classification&sort=downloads) models, [Hugging Face zero shot classification](https://huggingface.co/models?pipeline_tag=zero-shot-classification&sort=downloads) models, and of course with your own models.
 
+## Batch
+
+Batch processing is coming soon. Already available with Tf-Idf retriever.
+
 ## Summarization and question answering
 
 Cherche provides modules dedicated to summarization and question answering. These modules are compatible with Hugging Face's pre-trained models and fully integrated into neural search pipelines.

--- a/README.md
+++ b/README.md
@@ -138,9 +138,20 @@ Cherche provides different [retrievers](https://raphaelsty.github.io/cherche/ret
 
 Cherche rankers are compatible with [SentenceTransformers](https://www.sbert.net/docs/pretrained_models.html) models, [Hugging Face sentence similarity](https://huggingface.co/models?pipeline_tag=zero-shot-classification&sort=downloads) models, [Hugging Face zero shot classification](https://huggingface.co/models?pipeline_tag=zero-shot-classification&sort=downloads) models, and of course with your own models.
 
-## Batch
+## Batch - soon
 
-Batch processing is coming soon. Already available with Tf-Idf retriever.
+Retrieving documents with batch of queries can significantly speed up things. It is already available for few models using the **development version** via the `batch` method.
+
+Models involved are:
+
+- TfIdf retriever
+- Encoder retriever
+- Encoder ranker
+- DPR retriever
+- DPR ranker
+- Recommend retriever
+
+Batch is not yet compatible with pipelines.
 
 ## Summarization and question answering
 

--- a/cherche/index/milvus.py
+++ b/cherche/index/milvus.py
@@ -487,3 +487,6 @@ class Milvus:
             embeddings,
             [key for key in values if key not in known],
         )
+
+    def batch(self, **kwargs):
+        raise NotImplementedError("Batch is only available for Faiss index yet.")

--- a/cherche/index/tree.py
+++ b/cherche/index/tree.py
@@ -156,7 +156,8 @@ class Faiss:
                     **self.documents[idx],
                     "similarity": float(1 / d) if d > 0 else 0.0,
                 }
-                for d, idx in zip(distance, index) if idx > -1
+                for d, idx in zip(distance, index)
+                if idx > -1
             ]
             for q, (distance, index) in enumerate(zip(distances, indexes))
         }

--- a/cherche/index/tree.py
+++ b/cherche/index/tree.py
@@ -156,7 +156,7 @@ class Faiss:
                     **self.documents[idx],
                     "similarity": float(1 / d) if d > 0 else 0.0,
                 }
-                for d, idx in zip(distance, index)
+                for d, idx in zip(distance, index) if idx > -1
             ]
             for q, (distance, index) in enumerate(zip(distances, indexes))
         }

--- a/cherche/index/tree.py
+++ b/cherche/index/tree.py
@@ -139,3 +139,24 @@ class Faiss:
             ranked.append(document)
 
         return ranked
+
+    def batch(
+        self, embeddings: np.ndarray, k: int = None, n: int = 0, **kwargs
+    ) -> list:
+
+        if k is None:
+            k = len(self)
+
+        distances, indexes = self.index.search(embeddings, k)
+
+        return {
+            q
+            + n: [
+                {
+                    **self.documents[idx],
+                    "similarity": float(1 / d) if d > 0 else 0.0,
+                }
+                for d, idx in zip(distance, index)
+            ]
+            for q, (distance, index) in enumerate(zip(distances, indexes))
+        }

--- a/cherche/index/tree.py
+++ b/cherche/index/tree.py
@@ -135,7 +135,9 @@ class Faiss:
                 continue
 
             document = self.documents[idx]
-            document["similarity"] = float(1 / distance) if distance > 0 else 0.0
+            document["similarity"] = (
+                float(1 / (distance + 1e-4)) if distance > 0 else 0.0
+            )
             ranked.append(document)
 
         return ranked
@@ -154,7 +156,7 @@ class Faiss:
             + n: [
                 {
                     **self.documents[idx],
-                    "similarity": float(1 / d) if d > 0 else 0.0,
+                    "similarity": float(1 / (d + 1e-4)) if d >= 0 else 0.0,
                 }
                 for d, idx in zip(distance, index)
                 if idx > -1

--- a/cherche/rank/base.py
+++ b/cherche/rank/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 __all__ = ["Ranker"]
 
 import abc
+import collections
 import typing
 
 import more_itertools
@@ -182,6 +183,69 @@ class Ranker(abc.ABC):
             document["similarity"] = similarity
             ranked.append(document)
         return ranked
+
+    def encode_batch(self, batch: dict) -> dict:
+        """Encode batch of documents."""
+        values = []
+        index = collections.defaultdict(dict)
+
+        for idx, documents in batch.items():
+            for rank, document in enumerate(documents):
+                values.append(document[self.key])
+                index[idx][rank] = document
+
+        known, embeddings, unknown = self.store.get(
+            **{
+                "key": self.key,
+                "values": values,
+            }
+        )
+
+        embeddings = {idx: embedding for idx, embedding in zip(known, embeddings)}
+        embeddings_unknown = {
+            key_unknown: embedding
+            for key_unknown, embedding in zip(
+                unknown,
+                self.encoder(
+                    [
+                        " ".join(
+                            [index[key_unknown].get(field, "") for field in self.on]
+                        )
+                        for key_unknown in unknown
+                    ]
+                ),
+            )
+        }
+
+        return {**embeddings, **embeddings_unknown}, index
+
+    def rank_batch(self, query_embeddings: np.ndarray, batch: dict, n: int = 0) -> dict:
+        """Produce ranking in batch."""
+        documents_embeddings, index = self.encode_batch(batch=batch)
+        documents_embeddings = [
+            np.stack(
+                [documents_embeddings[document[self.key]] for document in documents],
+                axis=0,
+            ).T
+            for q, documents in batch.items()
+        ]
+
+        array_ranks, array_similarities = self.similarity(
+            emb_q=query_embeddings,
+            emb_documents=documents_embeddings,
+            batch=True,
+            k=self.k,
+        )
+
+        return {
+            idx: [
+                {**documents[rank], **{"similarity": similarity}}
+                for rank, similarity in zip(ranks, similarities)
+            ]
+            for ranks, similarities, (idx, documents) in zip(
+                array_ranks, array_similarities, index.items()
+            )
+        }
 
     def __add__(self, other) -> Pipeline:
         """Pipeline operator."""

--- a/cherche/rank/base.py
+++ b/cherche/rank/base.py
@@ -141,8 +141,11 @@ class Ranker(abc.ABC):
             )
         return self
 
-    def encode(self, documents: list) -> typing.Tuple[dict, list]:
+    def encode(
+        self, documents: list, recommender: bool = False
+    ) -> typing.Tuple[dict, list]:
         """Computes documents embeddings."""
+        # Get known documents ids, embeddings of known documents and unknown documents ids.
         known, embeddings, unknown = self.store.get(
             **{
                 "key": self.key,
@@ -151,12 +154,15 @@ class Ranker(abc.ABC):
         )
         index = {document[self.key]: document for document in documents}
 
-        embeddings_unknown = self.encoder(
-            [
-                " ".join([index[key_unknown].get(field, "") for field in self.on])
-                for key_unknown in unknown
-            ]
-        )
+        # Encode unknown documents:
+        embeddings_unknown = []
+        if unknown:
+            embeddings_unknown = self.encoder(
+                [
+                    " ".join([index[key_unknown].get(field, "") for field in self.on])
+                    for key_unknown in unknown
+                ]
+            )
 
         return {
             idx: index.get(key_document)

--- a/cherche/rank/dpr.py
+++ b/cherche/rank/dpr.py
@@ -5,6 +5,9 @@ __all__ = ["DPR"]
 
 import typing
 
+import more_itertools
+import tqdm
+
 from ..similarity import dot
 from .base import MemoryStore, Ranker
 
@@ -59,9 +62,34 @@ class DPR(Ranker):
         similarity: dot
         Embeddings pre-computed: 3
 
+    >>> print(ranker.batch(
+    ...    q=["Paris", "Montreal"],
+    ...    documents={
+    ...         0: [{"id": 0}, {"id": 1}, {"id": 2}],
+    ...         1: [{"id": 0}, {"id": 1}, {"id": 2}]
+    ...    }
+    ... ))
+    {0: [{'id': 0, 'similarity': 74.02354}, {'id': 1, 'similarity': 68.806526}],
+     1: [{'id': 2, 'similarity': 74.88396}, {'id': 1, 'similarity': 60.880127}]}
+
+    >>> print(ranker.batch(
+    ...    q=["Paris", "Montreal"],
+    ...    batch_size=1,
+    ...    documents={
+    ...         0: [{"id": 0}, {"id": 1}, {"id": 2}],
+    ...         1: [{"id": 0}, {"id": 1}, {"id": 2}]
+    ...    }
+    ... ))
+    {0: [{'id': 0, 'similarity': 74.02354}, {'id': 1, 'similarity': 68.80652}],
+     1: [{'id': 2, 'similarity': 74.883965}, {'id': 1, 'similarity': 60.880142}]}
+
     >>> print(ranker(q="Paris", documents=[{"id": 0}, {"id": 1}, {"id": 2}]))
     [{'id': 0, 'similarity': 74.0235366821289},
      {'id': 1, 'similarity': 68.8065185546875}]
+
+    >>> print(ranker(q="Montreal", documents=[{"id": 0}, {"id": 1}, {"id": 2}]))
+    [{'id': 2, 'similarity': 74.88396453857422},
+     {'id': 1, 'similarity': 60.88014221191406}]
 
     >>> print(ranker(q="Paris", documents=documents))
     [{'article': 'This town is the capital of France',
@@ -76,17 +104,16 @@ class DPR(Ranker):
       'title': 'Eiffel tower'}]
 
     >>> ranker += documents
-
-    >>> print(ranker(q="Paris", documents=[{"id": 0}, {"id": 1}, {"id": 2}]))
-    [{'article': 'This town is the capital of France',
+    >>> print(ranker(q="Montreal", documents=[{"id": 0}, {"id": 1}, {"id": 2}]))
+    [{'article': 'Montreal is in Canada.',
       'author': 'Wiki',
-      'id': 0,
-      'similarity': 74.0235366821289,
-      'title': 'Paris'},
+      'id': 2,
+      'similarity': 74.88396453857422,
+      'title': 'Montreal'},
      {'article': 'Eiffel tower is based in Paris',
       'author': 'Wiki',
       'id': 1,
-      'similarity': 68.8065185546875,
+      'similarity': 60.88014221191406,
       'title': 'Eiffel tower'}]
 
     """
@@ -126,3 +153,41 @@ class DPR(Ranker):
             query_embedding=self.query_encoder(q),
             documents=documents,
         )
+
+    def batch(
+        self, q: typing.List[str], documents: dict, batch_size: int = 64, **kwargs
+    ) -> dict:
+        """Re-rank batch of documents-queries.
+
+        Parameters
+        ----------
+        q
+            List of queries.
+        documents
+            Batch of documents.
+        batch_size
+            Size of the batch.
+        """
+        rank = {}
+
+        for batch_queries, batch in tqdm.tqdm(
+            zip(
+                more_itertools.chunked(q, batch_size),
+                more_itertools.chunked(documents, batch_size),
+            ),
+            position=0,
+            desc="Ranker batch queries.",
+            total=1 + len(q) // batch_size,
+        ):
+            rank = {
+                **rank,
+                **self.rank_batch(
+                    **{
+                        "query_embeddings": self.query_encoder(batch_queries),
+                        "batch": {idx: documents[idx] for idx in batch},
+                        "n": len(rank),
+                    }
+                ),
+            }
+
+        return rank

--- a/cherche/rank/recommend.py
+++ b/cherche/rank/recommend.py
@@ -222,7 +222,7 @@ class Recommend(Ranker):
             return [{**document, "similarity": 0} for document in documents]
 
         index = {document[self.key]: document for document in documents}
-        index_known = {i: key  for i, key in enumerate(known)}
+        index_known = {i: key for i, key in enumerate(known)}
 
         ranked = [
             {**index[index_known[key]], "similarity": similarity}
@@ -233,4 +233,4 @@ class Recommend(Ranker):
 
         # Addind unknown documents
         ranked += [{**index[key], "similarity": 0} for key in unknown]
-        return ranked[:self.k] if self.k is not None else ranked
+        return ranked[: self.k] if self.k is not None else ranked

--- a/cherche/rank/recommend.py
+++ b/cherche/rank/recommend.py
@@ -229,8 +229,6 @@ class Recommend(Ranker):
             for key, similarity in self.similarity(
                 emb_q=embedding_user[0], emb_documents=embeddings
             )
-        ]
+        ] + [{**index[key], "similarity": 0} for key in unknown]
 
-        # Addind unknown documents
-        ranked += [{**index[key], "similarity": 0} for key in unknown]
         return ranked[: self.k] if self.k is not None else ranked

--- a/cherche/retrieve/dpr.py
+++ b/cherche/retrieve/dpr.py
@@ -52,28 +52,36 @@ class DPR(Retriever):
          documents: 3
 
     >>> print(retriever("Spain"))
-    [{'id': 1, 'similarity': 0.009192565994771673},
-     {'id': 0, 'similarity': 0.008331424302852155}]
+    [{'id': 1, 'similarity': 0.006858040774451286},
+     {'id': 0, 'similarity': 0.0060191201849380555}]
+
+    >>> print(retriever("Paris"))
+    [{'id': 0, 'similarity': 0.00816787668669813},
+     {'id': 1, 'similarity': 0.007023785549903056}]
+
+    >>> print(retriever.batch(["Spain", "Paris"]))
+    {0: [{'id': 1, 'similarity': 0.006858040774451286},
+         {'id': 0, 'similarity': 0.006019121290584248}],
+     1: [{'id': 0, 'similarity': 0.008167878213665493},
+         {'id': 1, 'similarity': 0.007023786302673574}]}
+
+    >>> print(retriever.batch(["Spain", "Paris"], batch_size=1))
+    {0: [{'id': 1, 'similarity': 0.006858040774451286},
+         {'id': 0, 'similarity': 0.0060191201849380555}],
+     1: [{'id': 0, 'similarity': 0.00816787668669813},
+         {'id': 1, 'similarity': 0.007023785549903056}]}
 
     >>> retriever += documents
 
     >>> print(retriever("Spain"))
     [{'author': 'Madrid',
       'id': 1,
-      'similarity': 0.009192565994771673,
+      'similarity': 0.006858040774451286,
       'title': 'Madrid'},
      {'author': 'Paris',
       'id': 0,
-      'similarity': 0.008331424302852155,
+      'similarity': 0.0060191201849380555,
       'title': 'Paris'}]
-
-    >>> print(retriever("Paris"))
-
-    >>> print(retriever.batch(["Spain", "Paris"]))
-    {0: [{'id': 1, 'similarity': 0.009192558902980534}, {'id': 0, 'similarity': 0.008331423243699596}], 1: [{'id': 0, 'similarity': 0.012557486004178293}, {'id': 1, 'similarity': 0.008042770416310565}]}
-
-    >>> print(retriever.batch(["Spain", "Paris"], batch_size=1))
-
 
     """
 
@@ -156,7 +164,7 @@ class DPR(Retriever):
 
     def batch(
         self,
-        q: list[str],
+        q: typing.List[str],
         batch_size: int = 64,
         expr: str = None,
         consistency_level: str = None,

--- a/cherche/retrieve/encoder.py
+++ b/cherche/retrieve/encoder.py
@@ -52,24 +52,24 @@ class Encoder(Retriever):
          documents: 3
 
     >>> print(retriever("Spain"))
-    [{'id': 1, 'similarity': 1.1885026511619967},
-     {'id': 0, 'similarity': 0.8492537121532174}]
+    [{'id': 1, 'similarity': 1.1885032405192992},
+     {'id': 0, 'similarity': 0.8492543139964137}]
 
     >>> print(retriever("Paris"))
-    [{'id': 0, 'similarity': 5.311705595297062},
-     {'id': 2, 'similarity': 1.1795194692378366}]
+    [{'id': 0, 'similarity': 5.311708958695876},
+     {'id': 2, 'similarity': 1.179519718015668}]
 
     >>> print(retriever.batch(["Spain", "Paris"]))
-    {0: [{'id': 1, 'similarity': 1.1885026511619967},
-         {'id': 0, 'similarity': 0.8492537981307646}],
-     1: [{'id': 0, 'similarity': 5.311705595297062},
-         {'id': 2, 'similarity': 1.1795194692378366}]}
+    {0: [{'id': 1, 'similarity': 1.188503156325363},
+         {'id': 0, 'similarity': 0.8492543139964137}],
+     1: [{'id': 0, 'similarity': 5.311706015721681},
+         {'id': 2, 'similarity': 1.1795198009416352}]}
 
     >>> print(retriever.batch(["Spain", "Paris"], batch_size=1))
-    {0: [{'id': 1, 'similarity': 1.1885026511619967},
-         {'id': 0, 'similarity': 0.8492537121532174}],
-     1: [{'id': 0, 'similarity': 5.311705595297062},
-         {'id': 2, 'similarity': 1.1795194692378366}]}
+    {0: [{'id': 1, 'similarity': 1.1885032405192992},
+         {'id': 0, 'similarity': 0.8492543139964137}],
+     1: [{'id': 0, 'similarity': 5.311708958695876},
+         {'id': 2, 'similarity': 1.179519718015668}]}
 
     References
     ----------
@@ -154,7 +154,7 @@ class Encoder(Retriever):
 
     def batch(
         self,
-        q: list[str],
+        q: typing.List[str],
         batch_size: int = 64,
         expr: str = None,
         consistency_level: str = None,

--- a/cherche/retrieve/recommend.py
+++ b/cherche/retrieve/recommend.py
@@ -118,7 +118,7 @@ class Recommend(Retriever):
         Users: 4
         Documents: 3
 
-    >>> print(recommend.batch(user=["Geoffrey", "Adil"]))
+    >>> print(recommend.batch(users=["Geoffrey", "Adil"]))
     {0: [{'id': 'c', 'similarity': 21229.834241369794},
          {'id': 'a', 'similarity': 21229.634204933023},
          {'id': 'b', 'similarity': 0.5075642957423536}],
@@ -265,14 +265,14 @@ class Recommend(Retriever):
             }
         )
 
-    def fitler(self, user: typing.List[typing.Union[str, int]]):
+    def fitler(self, users: typing.List[typing.Union[str, int]]):
         """Filter known users."""
-        known, _, unknown = self.store.get(values=user)
+        known, _, unknown = self.store.get(values=users)
         return known, unknown
 
     def batch(
         self,
-        user: typing.List[typing.Union[str, int]],
+        users: typing.List[typing.Union[str, int]],
         batch_size: int = 256,
         expr: str = None,
         consistency_level: str = None,
@@ -288,7 +288,7 @@ class Recommend(Retriever):
         batch_size
             Size of the batch.
         """
-        known, embeddings, unknown = self.store.get(values=user)
+        known, embeddings, unknown = self.store.get(values=users)
 
         if unknown:
             raise ValueError(f"Unknown users: {','.join(unknown)}")

--- a/cherche/retrieve/recommend.py
+++ b/cherche/retrieve/recommend.py
@@ -1,8 +1,7 @@
 import typing
 
-import numpy as np
-
 import more_itertools
+import numpy as np
 import tqdm
 
 from ..index import Faiss, Milvus
@@ -119,6 +118,14 @@ class Recommend(Retriever):
         Users: 4
         Documents: 3
 
+    >>> print(recommend.batch(user=["Geoffrey", "Adil"]))
+    {0: [{'id': 'c', 'similarity': 21229.834241369794},
+         {'id': 'a', 'similarity': 21229.634204933023},
+         {'id': 'b', 'similarity': 0.5075642957423536}],
+     1: [{'id': 'b', 'similarity': 5215.91262702973},
+         {'id': 'c', 'similarity': 0.5040069796422495},
+         {'id': 'a', 'similarity': 0.5040069796422495}]}
+
     >>> recommend += documents
 
     >>> print(recommend(user="Geoffrey"))
@@ -136,9 +143,18 @@ class Recommend(Retriever):
       'title': 'Madrid'}]
 
     >>> print(recommend(user="Adil"))
-
-    >>> print(recommend(user=["Geoffrey", "Adil"]))
-
+    [{'author': 'Madrid',
+      'id': 'b',
+      'similarity': 5215.91262702973,
+      'title': 'Madrid'},
+     {'author': 'Montreal',
+      'id': 'c',
+      'similarity': 0.5040069796422495,
+      'title': 'Montreal'},
+     {'author': 'Paris',
+      'id': 'a',
+      'similarity': 0.5040069796422495,
+      'title': 'Paris'}]
 
     References
     ----------
@@ -249,14 +265,14 @@ class Recommend(Retriever):
             }
         )
 
-    def fitler(self, user: list[typing.Union[str, int]]):
+    def fitler(self, user: typing.List[typing.Union[str, int]]):
         """Filter known users."""
         known, _, unknown = self.store.get(values=user)
         return known, unknown
 
     def batch(
         self,
-        user: list[typing.Union[str, int]],
+        user: typing.List[typing.Union[str, int]],
         batch_size: int = 256,
         expr: str = None,
         consistency_level: str = None,
@@ -291,7 +307,7 @@ class Recommend(Retriever):
                 **rank,
                 **self.index.batch(
                     **{
-                        "embedding": np.array(batch),
+                        "embeddings": np.array(batch),
                         "k": self.k,
                         "n": n,
                         "key": self.key,

--- a/cherche/retrieve/tfidf.py
+++ b/cherche/retrieve/tfidf.py
@@ -1,10 +1,10 @@
 __all__ = ["TfIdf"]
 
 import typing
-import tqdm
-import more_itertools
 
+import more_itertools
 import numpy as np
+import tqdm
 from scipy.sparse import csc_matrix
 from sklearn.feature_extraction.text import TfidfVectorizer
 
@@ -129,7 +129,7 @@ class TfIdf(Retriever):
 
         return [doc for doc in documents if doc["similarity"] > 0]
 
-    def batch(self, q: list[str], batch_size: int = 600, **kwargs) -> dict:
+    def batch(self, q: typing.List[str], batch_size: int = 600, **kwargs) -> dict:
         """Retrieve documents from batch of queries.
 
         Parameters


### PR DESCRIPTION
Retrieving documents with batch of queries can significantly speed up things. It is now available for few models using the **development version** via the `batch` method.

Models involved are:

- TfIdf retriever
- Encoder retriever (milvus + faiss)
- Encoder ranker (milvus)
- DPR retriever (milvus + faiss)
- DPR ranker (milvus)
- Recommend retriever

Batch is not yet compatible with pipelines.