### PR TITLE
fuzz retriever k default to what was passed to the constructor

### DIFF
--- a/cherche/retrieve/fuzz.py
+++ b/cherche/retrieve/fuzz.py
@@ -133,6 +133,9 @@ class Fuzz(Retriever):
             query will be retrieved.
         """
         if k is None:
+            k = self.k
+
+        if k is None:
             k = len(self.documents)
 
         rank = []


### PR DESCRIPTION
Hey!

Very nice neural search library.  I like the Pythonic design and have been finding it useful.

Here's a small bug where the `Fuzz` retriever was ignoring the `k=` that was passed to the constructor.

I tried adding some tests but didn't really understand the structure (I see that the `Fuzz` retriever isn't tested).